### PR TITLE
find a workaround if stow not installed, TBD

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ uv run install.py
 ```
 
 This script installs three components to `~/.config/opencode/`:
-- **Skills**: Linked from the `skills/` folder using GNU stow
-- **Prompts**: Linked from the `prompts/` folder using GNU stow  
+- **Skills**: Symlinked from the `skills/` folder
+- **Prompts**: Symlinked from the `prompts/` folder
 - **Config**: Merged with your existing OpenCode config (if any), overlaying only the options defined in `config/opencode.json`
+
+> **Windows**: Creating symlinks requires either running the terminal as Administrator, or enabling Developer Mode in _Settings → System → For developers_.
 
 ## Usage
 

--- a/install.py
+++ b/install.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import json
-import subprocess
 from pathlib import Path
 
 CONFIG_PATH = Path.home() / ".config" / "opencode" / "opencode.json"
@@ -53,43 +52,35 @@ def ensure_config():
     print(f"  Saved config to: {CONFIG_PATH}")
 
 
-def install_stow():
+def symlink_dir(src: Path, dest: Path):
+    """Symlink each file in src into dest, mirroring the directory structure."""
+    for src_file in src.rglob("*"):
+        if not src_file.is_file():
+            continue
+        rel = src_file.relative_to(src)
+        dest_file = dest / rel
+        dest_file.parent.mkdir(parents=True, exist_ok=True)
+        if dest_file.is_symlink():
+            dest_file.unlink()
+        dest_file.symlink_to(src_file)
+
+
+def install_files():
     print("\nInstalling files...")
     dest = Path.home() / ".config" / "opencode"
-    skills_dest = dest / "skills"
-    prompts_dest = dest / "prompts"
-
-    skills_dest.mkdir(parents=True, exist_ok=True)
-    prompts_dest.mkdir(parents=True, exist_ok=True)
 
     if SKILLS_SRC.exists():
-        subprocess.run(
-            [
-                "stow",
-                "-t",
-                str(skills_dest),
-                "-d",
-                str(SKILLS_SRC.parent),
-                SKILLS_SRC.name,
-            ],
-            check=True,
-        )
+        skills_dest = dest / "skills"
+        skills_dest.mkdir(parents=True, exist_ok=True)
+        symlink_dir(SKILLS_SRC, skills_dest)
         print(f"  Installed skills to: {skills_dest}")
     else:
         print(f"  No skills source found at: {SKILLS_SRC}, skipping")
 
     if PROMPTS_SRC.exists():
-        subprocess.run(
-            [
-                "stow",
-                "-t",
-                str(prompts_dest),
-                "-d",
-                str(PROMPTS_SRC.parent),
-                PROMPTS_SRC.name,
-            ],
-            check=True,
-        )
+        prompts_dest = dest / "prompts"
+        prompts_dest.mkdir(parents=True, exist_ok=True)
+        symlink_dir(PROMPTS_SRC, prompts_dest)
         print(f"  Installed prompts to: {prompts_dest}")
     else:
         print(f"  No prompts source found at: {PROMPTS_SRC}, skipping")
@@ -99,7 +90,7 @@ def install_stow():
 
 def main():
     ensure_config()
-    install_stow()
+    install_files()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I got this error when installing

```
uv run install.py
Using CPython 3.12.9 interpreter at: /Users/ren/miniconda3/bin/python3
Creating virtual environment at: .venv
Installed 21 packages in 69ms
Setting up config...
  Created config directory: /Users/ren/.config/opencode
  No existing config found, starting fresh
  Saved config to: /Users/ren/.config/opencode/opencode.json

Installing files...
Traceback (most recent call last):
  File "/Users/ren/switchdrive/backup/dev/_HEVS/opengrader/install.py", line 106, in <module>
    main()
  File "/Users/ren/switchdrive/backup/dev/_HEVS/opengrader/install.py", line 102, in main
    install_stow()
  File "/Users/ren/switchdrive/backup/dev/_HEVS/opengrader/install.py", line 66, in install_stow
    subprocess.run(
  File "/Users/ren/miniconda3/lib/python3.12/subprocess.py", line 550, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ren/miniconda3/lib/python3.12/subprocess.py", line 1028, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Users/ren/miniconda3/lib/python3.12/subprocess.py", line 1963, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'stow'
```

one workaround is to not use stow, but pure python. 

alternatively, we could **copy** the skills instead of symlink...